### PR TITLE
[정렬, 시뮬레이션] 세준세비(1524)

### DIFF
--- a/풀이/Minseon/done/BOJ/세준세비.cpp
+++ b/풀이/Minseon/done/BOJ/세준세비.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <algorithm>
+#include <deque>
+
+using namespace std;
+
+// * 세준이는 N명의 병사를 키웠고, 세비는 M명의 병사를 키웠다.
+// * 각 전투에서 살아있는 병사중 제일 약한 병사가 죽는다.
+// * - 제일 약한 병사가 여러 명이고, 제일 약한 병사가 모두 같은 편에 있다면, 그 중에 한 명이 임의로 선택되어 죽는다.
+// * - 제일 약한 병사가 여러 명이고, 양 편에 모두 있다면, 세비의 제일 약한 병사 중 한 명이 임의로 선택되어 죽는다.
+
+// ? 각 병사에 대해 vector에 입력을 받고, 각각 오름차순으로 정렬한다.
+// ? 남은 병사가 1명일 때까지 반복
+
+int main() {
+    cin.tie(nullptr);
+    ios::sync_with_stdio(false);
+
+    int T;
+    cin >> T;
+
+    int n, m, input_num;
+    while (T--)
+    {
+        cin >> n >> m;
+        deque<long long int> sejun;
+        for (int i = 0; i < n; ++i) {
+            cin >> input_num;
+            sejun.push_back(input_num);
+        }
+        deque<long long int> sebi(m);
+        for (int i = 0; i < m; ++i) {
+            cin >> input_num;
+            sebi.push_back(input_num);
+        }
+
+        sort(sejun.begin(), sejun.end());
+        sort(sebi.begin(), sebi.end());
+
+        while (sebi.size() + sejun.size() > 1) {
+            if (sejun.empty() || !sebi.empty() && sebi[0] <= sejun[0]) {
+                sebi.pop_front();
+            }
+            else if (sebi.empty() || !sejun.empty() && sejun[0] < sebi[0]) {
+                sejun.pop_front();
+            }
+        }
+
+        if (sebi.empty() && sejun.size() == 1) cout << "S\n";
+        else if (sejun.empty() && sebi.size() == 1) cout << "B\n";
+        else cout << "C\n";
+    }
+    
+
+    return 0;
+}


### PR DESCRIPTION
## 문제출처
[세준세비](https://www.acmicpc.net/status?user_id=msp1125&problem_id=1524&from_mine=1)

## 풀이 아이디어
- 두 팀의 병사의 합이 1보다 큰 동안, 조건에 따라 병사를 하나씩 제거하는 식으로 진행 (시뮬레이션)
- 병사가 제거되는 조건은 **가장 약한 병사**이므로, `오름차순 정렬`을 진행하여 **가장 앞에 있는 병사끼리 비교하여 제거**하였음.
- 배열 혹은 vector를 사용하면 시간초과가 뜰 수도 있을 것 같아서, pop & push가 비교적 자유로운 `deque`을 사용하였음.
- 문제 풀이를 진행하다가 `C를 출력하는 경우`가 무엇인지 이해가 안 돼서 조금 헤맸음. 

## 질문
근데 이 문제에서 **C가 출력될 수가 있나요??** 
C가 출력됐다는 건 세준, 세비 둘 다 이기지 않은 경우 -> 즉, 무승부라는 의미인데 게임은 `병사가 한 명만 남을 때까지 진행`되고, `각 전투에서 병사가 하나씩 사라지기` 때문에 제 생각에는 _두 병사가 동시에 0명이 되는 케이스_ 는 발생하지 않을 것 같은데요
준형오빠 풀이에서도 C를 출력하는 경우는 아예 없었던 것 같아서, 혹시 문제가 잘못된 건지 아니면 놓친게 있는지 궁금하네요 ~!