### PR TITLE
[다익스트라] - 지름길 (1446)

### DIFF
--- a/풀이/Minhyeok/done/[다익스트라]지름길.js
+++ b/풀이/Minhyeok/done/[다익스트라]지름길.js
@@ -1,0 +1,117 @@
+// 1446
+
+const readline = require("readline");
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+// 우선순위 큐에서 사용할 요소 클래스를 생성
+// element는 값이고, priority는 우선순위를 나타냅니다.
+class QElement {
+  constructor(element, priority) {
+    this.element = element;
+    this.priority = priority;
+  }
+}
+
+// 우선순위 큐 클래스를 생성
+class PriorityQueue {
+  constructor() {
+    this.queue = [];
+  }
+  // 우선순위에 따라 요소를 큐에 추가
+  enqueue(element, priority) {
+    let isContain = false;
+    const qElement = new QElement(element, priority);
+    for (let i = 0; i < this.queue.length; i++) {
+      if (this.queue[i].priority > qElement.priority) {
+        this.queue.splice(i, 0, qElement);
+        isContain = true;
+        break;
+      }
+    }
+    if (!isContain) {
+      this.queue.push(qElement);
+    }
+  }
+  // 큐에서 가장 높은 우선순위를 가진 요소를 제거하고 반환
+  dequeue() {
+    if (!this.isEmpty()) return this.queue.shift();
+  }
+  // 큐에서 가장 높은 우선순위를 가진 요소를 반환
+  front() {
+    if (!this.isEmpty()) return this.queue[0];
+  }
+  // 큐에서 가장 낮은 우선순위를 가진 요소를 반환
+  rear() {
+    if (!this.isEmpty()) return this.queue[this.queue.length - 1];
+  }
+  // 큐가 비어있는지 체크
+  isEmpty() {
+    return this.queue.length === 0;
+  }
+}
+
+const solution = function (input) {
+  // 첫 줄에서 지름길 개수와 고속도로 길이를 뽑아냄
+  const [N, D] = input
+    .shift()
+    .split(" ")
+    .map((e) => parseInt(e));
+  // dp 배열을 생성하고, 각 요소를 무한대로 초기화
+  // dp[i]는 i까지의 거리를 이동하는 데 필요한 최소 시간을 나타내기기
+  const dp = Array.from({ length: D + 1 }, () => Infinity);
+  // 각 위치에서 이동 가능한 경로를 저장하는 배열 생성
+  const edges = Array.from({ length: D + 1 }, () => []);
+  // 입력에서 지름길 정보를 추출하고 이동 가능한 경로를 edges 배열에 추가
+  for (const row of input) {
+    const [a, b, c] = row.split(" ").map((e) => parseInt(e));
+    if (D < b) continue;
+    if (b - a <= c) continue;
+    edges[a].push([b, c]);
+  }
+  // 우선순위 큐를 생성
+  const pq = new PriorityQueue();
+
+  // dp 배열의 첫 번째 요소를 0으로 설정
+  dp[0] = 0;
+  // 모든 위치에 대해 최소 이동 시간을 찾기
+  for (let start = 0; start <= D; start++) {
+    // 이전 위치에서 이동하는 시간을 현재 위치의 최소 이동 시간으로 설정
+    if (start > 0) {
+      dp[start] = Math.min(dp[start], dp[start - 1] + 1);
+    }
+
+    // 현재 위치를 우선순위 큐에 추가
+    pq.enqueue(start, dp[start]);
+    // 큐가 빌 때까지 반복!
+    while (!pq.isEmpty()) {
+      // 큐에서 가장 높은 우선순위를 가진 요소를 제거하고 반환합니다.
+      const qe = pq.dequeue();
+      // 큐 요소에서 위치를 추출
+      const currPos = qe.element;
+
+      // 현재 위치에서 이동할 수 있는 모든 위치에 대해
+      // 해당 위치로 이동하는 데 필요한 시간이 dp 배열에 저장된 시간보다 작은 경우
+      // dp 배열을 업데이트하고, 해당 위치를 우선순위 큐에 추가
+      for (const [nextPos, nextDist] of edges[currPos]) {
+        if (dp[nextPos] > dp[currPos] + nextDist) {
+          dp[nextPos] = dp[currPos] + nextDist;
+          pq.enqueue(nextPos, dp[nextPos]);
+        }
+      }
+    }
+  }
+  // 세준이가 이동해야 하는 최소 거리를 출력
+  console.log(dp[D]);
+};
+
+// 입력을 저장할 배열을 생성
+const input = [];
+rl.on("line", function (line) {
+  input.push(line);
+}).on("close", function () {
+  solution(input);
+  process.exit();
+});


### PR DESCRIPTION
## 문제출처
[지름길](https://www.acmicpc.net/problem/1446)

## **문제 : 세준이가 운전해야 하는 거리의 최솟값을 구하기**

![image](https://github.com/Junhyung-Choi/Algorithm/assets/42240254/79b19ab7-d5a7-442e-a29e-2a98dff1da58)

(내 친구 세준이는 면허 없던데..)

### 포인트

- 모든 길은 일방통행이고 고속도로를 역주행할 수는 없다.
- 만약 목적지 D가 150km인데 지름길을 통해 151km에 도착한다고 하면, 이 지름길은 사용할 수 없다.

### **예제에 대한 설명**

**예제 입력 :**
5 150
0 50 10
0 50 20
50 100 10
100 151 10
110 140 90

**예제 입력에 대한 출력 :**
70

고속도로의 길이는 150km이며, 사용 가능한 지름길은 5가지

1. 0km에서 50km로, 길이 10km
2. 0km에서 50km로, 길이 20km
3. 50km에서 100km로, 길이 10km
4. 100km에서 151km로, 길이 10km
5. 110km에서 140km로, 길이 90km

**위에 대한 설**

- 첫 번째와 두 번째 지름길 중 더 짧은 10km 지름길을 선택.
- 그 다음, 50km에서 100km로 가는 10km 지름길 사용. 지금까지 이동한 거리는 20km.
- 100km에서 151km로 가는 지름길은 고속도로의 끝을 넘어가므로 사용 불가.
- 마찬가지로, 110km에서 140km로 가는 90km 지름길은 시작점이 현재 위치보다 뒤쪽이므로 사용 불가.
- 따라서 나머지 50km는 일반 도로를 이용. 총 이동 거리는 20km(지름길) + 50km(일반 도로) = 70km.

### 문제 풀이 때 생각했던 것

0부터 D까지의 모든 지점에 대해 다익스트라를 수행해야 하므로, dp[i]는 i km까지 이동하는데 필요한 최소 시간을 의미!

그리고 dp 배열의 길이를 D+1로 설정하여 모든 지점을 포함하도록 했습니다!

우선순위 큐를 사용하여 각 지점까지의 최소 시간을 저장하고, 각 지점에서 이동할 수 있는 모든 지점을 순회하면서 dp 값을 업데이트합니다.

이 때, 우선순위 큐에는 현재 지점을 기준으로 다음에 이동할 지점과 그 지점까지의 최소 시간을 저장!