### PR TITLE
Solve: [크루스칼] 최소 스패닝 트리

### DIFF
--- a/풀이/Minhyeok/done/[크루스칼]최소스패닝트리.js
+++ b/풀이/Minhyeok/done/[크루스칼]최소스패닝트리.js
@@ -1,0 +1,51 @@
+// 본인이 선택한 언어로 풀이해주세요.
+// https://www.acmicpc.net/problem/1197
+
+const fs = require("fs");
+const input = fs.readFileSync("/dev/stdin").toString().trim().split("\n");
+
+// 첫 번째 줄에서 정점(V)과 간선(E)의 수를 구함
+const [V, E] = input[0].split(" ").map(Number);
+// 나머지 줄에서 간선 정보를 추출
+const edges = input.slice(1).map((line) => line.split(" ").map(Number));
+
+// 간선들을 가중치를 기준으로 오름차순 정렬
+edges.sort((a, b) => a[2] - b[2]);
+
+// 부모 테이블 초기화: 각 정점의 부모는 자기 자신으로 설정
+let parent = Array(V + 1)
+  .fill(0)
+  .map((_, idx) => idx);
+
+// Find 연산: 특정 원소가 속한 집합을 찾기
+const find = (u) => {
+  // 루트 노드를 찾을 때까지 재귀적으로 호출
+  if (u === parent[u]) return u;
+  return (parent[u] = find(parent[u]));
+};
+
+// Union 연산: 두 집합을 합치기
+const union = (u, v) => {
+  u = find(u);
+  v = find(v);
+  // 두 원소가 속한 집합이 다르다면 합치기
+  if (u !== v) {
+    parent[u] = v;
+  }
+};
+
+let result = 0;
+
+// 모든 간선에 대하여 확인
+for (let i = 0; i < E; i++) {
+  const [a, b, w] = edges[i];
+
+  // 사이클을 형성하지 않는 경우에만 간선을 추가
+  if (find(a) !== find(b)) {
+    union(a, b);
+    result += w; // 최소 스패닝 트리의 가중치에 더하기
+  }
+}
+
+// 최소 스패닝 트리의 가중치 합 출력
+console.log(result);

--- a/풀이/Minhyeok/todo/[크루스칼]최소스패닝트리.js
+++ b/풀이/Minhyeok/todo/[크루스칼]최소스패닝트리.js
@@ -1,2 +1,0 @@
-// 본인이 선택한 언어로 풀이해주세요.
-// https://www.acmicpc.net/problem/1197


### PR DESCRIPTION
<img src="https://github.com/Junhyung-Choi/Algorithm/assets/42240254/202bf0a7-cc49-4a7c-827b-8e5235571ad2" width="400" height="400"/>

이젠 컴퓨터가 욕도 하네요...

## 문제출처
[최소 스패닝 트리](https://www.acmicpc.net/problem/1197)

## 문제 Point

- 그래프의 정점 수는 V, 간선 수는 E입니다.
- 각 간선은 시작 정점 A, 끝 정점 B, 그리고 해당 간선의 가중치 C로 주어집니다.
- 이 간선들 중 일부를 선택하여 모든 정점을 포함하는 트리를 만들되, 선택된 간선들의 가중치 합이 최소가 되도록 합니다.


## 풀이 아이디어

이 문제는 크루스칼 알고리즘을 확실히 익힌다면 쉽게 풀 수 있는 문제입니다! (사실 그게 어려워요..)

문제와 관련하여 크루스칼과 유니온-파인드 알고리즘의 동작 방식을 조금 요약해보자면,

### 크루스칼 알고리즘

**1. 간선 정렬** : 모든 간선들을 가중치를 기준으로 오름차순 정렬합니다.
**2. 간선 선택** : 정렬된 간선 중 가장 가중치가 작은 간선부터 선택합니다.
**3. 사이클 검사** : 선택된 간선이 트리 내에서 사이클을 형성하는지 확인합니다. (이를 위해 **유니온-파인드 알고리즘**이 사용됩니다.)
**4. 트리 추가** : 사이클을 형성하지 않으면 해당 간선을 트리에 추가합니다.
**5, 종료 조건** : 트리에 포함된 간선의 수가 (정점의 수 - 1)이 되면 종료합니다.

### 유니온-파인드 알고리즘

**1. find 연산** : 특정 원소가 속한 집합을 찾습니다.
**2. union 연산** : 두 집합을 하나로 합칩니다.

코드 내에서는 find 함수를 사용하여 간선의 두 정점이 현재 같은 집합에 속하는지(즉, 사이클을 형성하는지)를 확인합니다.
만약 같은 집합에 속하지 않다면, union 함수를 사용하여 두 정점을 같은 집합에 속하게 합니다.
이 과정을 모든 간선에 대해 반복하면 최소 스패닝 트리를 얻을 수 있습니다.

## 예제 풀이


### 1. 예제 입력
```
3 3
1 2 1
2 3 2
1 3 3
```

### 2. 정점(V)과 간선(E)의 수 추출

`const [V, E] = input[0].split(" ").map(Number);
`
- 여기서 V는 3, E는 3으로 할당

### 3. 간선 정보 추출

`const edges = input.slice(1).map(line => line.split(" ").map(Number));
`
- edges는 [[1, 2, 1], [2, 3, 2], [1, 3, 3]]로 할당


### 4. 간선들을 가중치를 기준으로 오름차순 정렬

`edges.sort((a, b) => a[2] - b[2]);
`
- 정렬된 edges는 [[1, 2, 1], [2, 3, 2], [1, 3, 3]]로 그대로 유지됩니다.

### 5. 부모 테이블 초기화

`let parent = Array(V + 1).fill(0).map((_, idx) => idx);
`
- parent는 [0, 1, 2, 3]로 초기화됩니다. 이는 각 정점의 부모는 처음에 자기 자신으로 설정됩니다.
- 이후 FInd 및 Union 연산 함수가 적용됩니다.

### 6. 모든 간선에 대해 확인

```
for (let i = 0; i < E; i++) {
    const [a, b, w] = edges[i];
    if (find(a) !== find(b)) {
        union(a, b);
        result += w;
    }
}
```
- 첫 번째 간선 [1, 2, 1]: 1과 2의 루트는 각각 1과 2입니다. 사이클을 형성하지 않으므로 union 연산을 수행하고, result에 1을 더합니다.
- 두 번째 간선 [2, 3, 2]: 2의 루트는 1, 3의 루트는 3입니다. 사이클을 형성하지 않으므로 union 연산을 수행하고, result에 2를 더합니다.
- 세 번째 간선 [1, 3, 3]: 1과 3의 루트는 모두 1입니다. 사이클을 형성하므로 이 간선은 추가하지 않습니다.

