### PR TITLE
[크루스칼] 도시분할계획(1647)

### DIFF
--- a/풀이/Juhee/repeat/[크루스칼]도시분할계획.js
+++ b/풀이/Juhee/repeat/[크루스칼]도시분할계획.js
@@ -1,0 +1,67 @@
+// https://www.acmicpc.net/problem/1647
+
+let fs = require("fs");
+let input = fs
+  .readFileSync(process.platform === "linux" ? "/dev/stdin" : "test.txt")
+  .toString()
+  .trim()
+  .split("\n");
+
+// 마을에는 집이 하나 이상 있어야 하며, 분리된 마을 안에 있는 임의의 '두 집 사이에 경로가 항상 존재', 문제에서 파악 가능한 정보: 모든 집들은 연결되어 있다.
+// 사이클의 존재 여부 -> Union/Find 알고리즘을 활용하여 해결 가능하다
+
+const solution = (input) => {
+  const [N, M] = input.shift().split(" ").map(Number);
+  let road = input.map((line) => line.split(" ").map(Number));
+
+  // 1. 유지비를 기준으로 오름차순으로 정렬
+  road.sort((a, b) => a[2] - b[2]);
+
+  // 2. Union-Find 활용을 위한 parent 초기화
+  let parent = new Array(N + 1).fill(0);
+  for (let i = 0; i <= N; i++) parent[i] = i;
+
+  // 3. 사이클 없이 간선을 이을 수 있는 스패닝 트리 저장
+  let MST = [];
+
+  for (let i = 0; i < M; i++) {
+    const [from, to, cost] = road[i];
+    // 3-1. 사이클 체크
+    if (!findParent(from, to, parent)) {
+      unionParent(from, to, parent);
+      MST.push([from, to, cost]);
+    }
+  }
+  // 4. 비용이 제일 높은 간선 자르기 (비용을 기준으로 오름차순 하였기 때문에 pop 하면 비용 가장 높은 값이 제외됨)
+  let answer = 0;
+  MST.pop();
+  for (let i = 0; i < MST.length; i++) {
+    answer += MST[i][2];
+  }
+
+  return answer;
+};
+
+/** x의 부모 검사 */
+const getParent = (x, parent) => {
+  if (parent[x] === x) return x;
+  else return (parent[x] = getParent(parent[x], parent)); // return 이 있어야 축약됨.
+};
+
+/** a, b가 parent 로부터 연결되어 있는지 검사 */
+const findParent = (a, b, parent) => {
+  a = getParent(a, parent);
+  b = getParent(b, parent);
+  if (a === b) return true;
+  else return false;
+};
+
+/** a, b를 하나의 부모로 연결 */
+const unionParent = (a, b, parent) => {
+  a = parent[a];
+  b = parent[b];
+  if (a < b) parent[b] = a;
+  else parent[a] = b;
+};
+
+console.log(solution(input));

--- a/풀이/Juhee/todo/[크루스칼]도시분할계획.js
+++ b/풀이/Juhee/todo/[크루스칼]도시분할계획.js
@@ -1,2 +1,0 @@
-// 본인이 선택한 언어로 풀이해주세요.
-// https://www.acmicpc.net/problem/1647


### PR DESCRIPTION
## 문제출처
[도시분할계획](https://www.acmicpc.net/problem/1647)

## 크루스칼 알고리즘

오늘은 핑계부터 시작하는 풀이입니다 ㅎ.ㅎ 크루스칼 알고리즘은 풀 기회가 적었어서..!!! 다시 한 번 개념을 정리하고 시작해보겠습니다 🥹

신장 트리 중에서 최소 비용으로 만들 수 있는 신장 트리를 찾는 알고리즘을 `최소 신장 트리 알고리즘` 이라고 하는데, 대표적인 최소 신장 트리 알고리즘으로는 `크루스칼 알고리즘`이 있습니다. 크루스칼 알고리즘을 사용하면 가장 적은 비용으로 모든 노드를 연결할 수 있다고 해요! (**현재 문제에서 원하는 이것! 가장 적은 비용으로 마을을 2등분시켜(?) 연결하고 싶어요**)

- 크루스칼 알고리즘은 대표적인 **최소 신장 트리 알고리즘**입니다.

- 그리디 알고리즘으로도 분류됩니다.

### 신장 트리는 뭔데...

- 신장 트리란 하나의 그래프가 있을 때 `모든 노드를 포함`하면서 `사이클이 존재하지 않는` 부분 그래프를 의미합니다.

| 신장 트리 O | 모든 노드가 포함되어 있지 않아 신장 트리 X | 사이클이 존재하여 신장 트리 X |
|---|---|---|
| <img width="407" alt="image" src="https://github.com/Junhyung-Choi/Algorithm/assets/57554421/fbf12c5e-7141-4918-8c8e-758cda84d066"> | <img width="427" alt="image" src="https://github.com/Junhyung-Choi/Algorithm/assets/57554421/c703d842-8229-4760-bead-1730d8797363"> | <img width="447" alt="image" src="https://github.com/Junhyung-Choi/Algorithm/assets/57554421/b26dbd7e-e552-42a5-90f8-542fda1ad617"> | 

크루스칼 알고리즘은 위처럼 신장 트리 중에서도 ⭐️최소한의 비용⭐️으로 만들 수 있는 최소 신장 트리를 찾는 알고리즘입니다. 


### 수도 코드

1. 간선 데이터를 비용에 따라 오름차순으로 정렬한다. -> 오름차순 정렬을 해야 추후에 **가장 큰 비용의 간선을 제거**하여 최소의 비용을 가지는 최소 신장 트리를 찾을 수 있습니다.
2. 간선을 하나씩 확인하며 현재의 간선이 사이클을 발생시키는지 확인한다.
  2-1. 사이클이 발생하지 않는 경우 최소 신장 트리에 포함시킨다.
  2-2. 사이클이 발생하는 경우 최소 신장 트리에 포함시키지 않는다. (X)
3. 모든 간선에 대하여 2번의 과정을 반복한다.

따라서 위에 과정을 반복하기 위해 `Union-Find` 알고리즘을 활용합니다.


## 풀이 아이디어

현재 문제에서 크루스칼 알고리즘을 사용할 수 있는 이유를 파악해봅시다!

- 조건
  - 집 간의 연결 관계가 주어지므로 방향성이 고려되지 않는다 (길은 어느 방향으로든지 다닐 수 있는 편리한 길)
  - 모든 노드가 포함되어 있다 (임의의 두 집 사이에 경로가 항상 존재)

- 구하고자 하는 값
    - 마을을 분할할 때는 각 분리된 마을 안에 집들이 서로 연결되도록 분할해야 하며, 각 분리된 마을 안에 있는 임의의 두 집 사이에 경로가 항상 존재해야 한다
  - 나머지 길의 유지비의 합을 최소로 하고 싶다.

문제의 조건에 따라 `무방향`, `모든 노드가 포함`되어 있다는 것을 확인할 수 있었고, 구하고자 하는 값도, `모든 노드가 포함`되어 있어야 하며, `비용을 최소`로 해야한다는 것을 파악할 수 있었습니다.

따라서 크루스칼 알고리즘을 활용하여 가장 비용이 큰 간선을 제거함으로써, 유지비를 최소로 하며 마을을 2등분 했을 때(?)의 비용을 구할 수 있습니다.